### PR TITLE
Add gateway exception handler for feign clients

### DIFF
--- a/gateway-service/src/main/java/org/java/mentorship/gateway/config/FeignConfig.java
+++ b/gateway-service/src/main/java/org/java/mentorship/gateway/config/FeignConfig.java
@@ -1,0 +1,15 @@
+package org.java.mentorship.gateway.config;
+
+import feign.codec.ErrorDecoder;
+import org.java.mentorship.gateway.exception.handler.FeignHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeignConfig {
+
+    @Bean
+    public ErrorDecoder errorDecoder() {
+        return new FeignHandler();
+    }
+}

--- a/gateway-service/src/main/java/org/java/mentorship/gateway/exception/domain/APIErrorResponse.java
+++ b/gateway-service/src/main/java/org/java/mentorship/gateway/exception/domain/APIErrorResponse.java
@@ -1,0 +1,12 @@
+package org.java.mentorship.gateway.exception.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class APIErrorResponse {
+
+    private String message;
+
+}

--- a/gateway-service/src/main/java/org/java/mentorship/gateway/exception/domain/GatewayException.java
+++ b/gateway-service/src/main/java/org/java/mentorship/gateway/exception/domain/GatewayException.java
@@ -1,0 +1,18 @@
+package org.java.mentorship.gateway.exception.domain;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.springframework.http.HttpStatus;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class GatewayException extends RuntimeException {
+
+    private final HttpStatus statusCode;
+
+    public GatewayException(String message, HttpStatus statusCode) {
+        super(message);
+        this.statusCode = statusCode;
+    }
+
+}

--- a/gateway-service/src/main/java/org/java/mentorship/gateway/exception/handler/FeignHandler.java
+++ b/gateway-service/src/main/java/org/java/mentorship/gateway/exception/handler/FeignHandler.java
@@ -1,0 +1,19 @@
+package org.java.mentorship.gateway.exception.handler;
+
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import org.java.mentorship.gateway.exception.domain.GatewayException;
+import org.springframework.http.HttpStatus;
+
+public class FeignHandler implements ErrorDecoder {
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        return switch (response.status()) {
+            case 400 -> new GatewayException("Bad Request", HttpStatus.BAD_REQUEST);
+            case 404 -> new GatewayException("Not Found", HttpStatus.NOT_FOUND);
+            case 500 -> new GatewayException("Internal Server Error", HttpStatus.INTERNAL_SERVER_ERROR);
+            default -> new GatewayException("Unknown error", HttpStatus.INTERNAL_SERVER_ERROR);
+        };
+    }
+}

--- a/gateway-service/src/main/java/org/java/mentorship/gateway/exception/handler/GeneralExceptionHandler.java
+++ b/gateway-service/src/main/java/org/java/mentorship/gateway/exception/handler/GeneralExceptionHandler.java
@@ -1,0 +1,31 @@
+package org.java.mentorship.gateway.exception.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.java.mentorship.gateway.exception.domain.APIErrorResponse;
+import org.java.mentorship.gateway.exception.domain.GatewayException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GeneralExceptionHandler {
+
+    @ExceptionHandler(GatewayException.class)
+    public ResponseEntity<APIErrorResponse> handle(final GatewayException exception, final HttpServletRequest request) {
+        return ResponseEntity.status(exception.getStatusCode())
+                .body(new APIErrorResponse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<APIErrorResponse> handle(final RuntimeException exception, final HttpServletRequest request) {
+        log.error(String.format("[%s] Caught exception: %s",
+                request.getRequestURI(),
+                exception.getMessage()));
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new APIErrorResponse("Unknown server error."));
+    }
+
+}


### PR DESCRIPTION
I added an exception handler for common response codes from the feign clients, so the response of the gateway endpoints will always be the same as the response from the feign clients (instead of internal server errro always)